### PR TITLE
Added Analytics tab for each document

### DIFF
--- a/docs-web/src/main/webapp/src/app/docs/app.js
+++ b/docs-web/src/main/webapp/src/app/docs/app.js
@@ -355,6 +355,15 @@ angular.module('docs',
         }
       }
     })
+    .state('document.view.analytics', {
+      url: '/analytics',
+      views: {
+        'tab': {
+          templateUrl: 'partial/docs/document.view.analytics.html',
+          controller: 'DocumentViewAnalytics'
+        }
+      }
+    })
     .state('login', {
       url: '/login?redirectState&redirectParams',
       views: {

--- a/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentViewAnalytics.js
+++ b/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentViewAnalytics.js
@@ -3,6 +3,6 @@
 /**
  * Document view workflow controller.
  */
-angular.module('docs').controller('DocumentViewAnalytics', function ($scope, $stateParams, Restangular, $translate, $dialog) {
+angular.module('docs').controller('DocumentViewAnalytics', function ($scope, $stateParams, Restangular) {
 //   currently does nothing
 });

--- a/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentViewAnalytics.js
+++ b/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentViewAnalytics.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Document view workflow controller.
+ */
+angular.module('docs').controller('DocumentViewAnalytics', function ($scope, $stateParams, Restangular, $translate, $dialog) {
+//   currently does nothing
+});

--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -68,6 +68,7 @@
     <script src="app/docs/controller/document/DocumentViewWorkflow.js" type="text/javascript"></script>
     <script src="app/docs/controller/document/DocumentViewPermissions.js" type="text/javascript"></script>
     <script src="app/docs/controller/document/DocumentViewActivity.js" type="text/javascript"></script>
+    <script src="app/docs/controller/document/DocumentViewAnalytics.js" type="text/javascript"></script>
     <script src="app/docs/controller/document/DocumentModalShare.js" type="text/javascript"></script>
     <script src="app/docs/controller/document/DocumentModalPdf.js" type="text/javascript"></script>
     <script src="app/docs/controller/document/DocumentModalAddTag.js" type="text/javascript"></script>

--- a/docs-web/src/main/webapp/src/locale/en.json
+++ b/docs-web/src/main/webapp/src/locale/en.json
@@ -148,6 +148,12 @@
       "activity": {
         "activity": "Activity",
         "message": "Every actions on this document are logged here."
+      },
+      "analytics": {
+        "analytics": "Analytics",
+        "message": "Summary of reviewers' scores are listed here.",
+        "no_reviewers": "Number of Reviewers",
+        "avg_scores": "Scores by Category"
       }
     },
     "edit": {

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.analytics.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.analytics.html
@@ -1,0 +1,11 @@
+<p class="well-sm" translate="document.view.analytics.message"></p>
+
+<div class="well">
+    
+    <h3>{{ 'document.view.analytics.no_reviewers' | translate }}</h3>
+    <p> 3 reviewers </p>
+
+    <h3>{{ 'document.view.analytics.avg_scores' | translate }}</h3>
+    <p> 80, 90, 100 </p>
+
+</div>

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.html
@@ -91,6 +91,11 @@
             <span class="fas fa-tasks"></span> {{ 'document.view.activity' | translate }}
           </a>
         </li>
+        <li ng-class="{ active: $state.current.name == 'document.view.analytics' }">
+          <a href="#/document/view/{{ document.id }}/analytics">
+            <span class="fas fa-star-half"></span> {{ 'document.view.analytics' | translate }}
+          </a>
+        </li>
       </ul>
       <div ui-view="tab"></div>
     </div>


### PR DESCRIPTION
Resolves #4 

**Description**
Adds a tab called “Analytics” (accessible through the /documents/view/\<document-id\>) for each document. This tab is accessible through the Documents dashboard, but currently has no relevant content.

**Changes:**
- document.view.analytics.html -> front-end of the Analytics tab when clicked on
- DocumentViewAnalytics.js -> empty JavaScript controller; is meant for calling the API to retrieve all reviewer totals and average scores
- app.js -> added an ‘analytics’ configuration state to connect the Analytics controller and document.view.analytics.html
- index.html -> imported Analytics controller script
- document.view.html -> includes Analytics in the list of tabs

**Testing:**
Passes all old tests after running the command `$ mvn test`. Passes manual inspection of creating document and seeing the Analytics tab for that document. There is no Java tests that can be created at this stage because loading the tab isn't based on the Teedy API.

**Screenshot of the Current Output:**
![Screen Shot 2022-10-03 at 7 57 17 PM](https://user-images.githubusercontent.com/45546627/193706405-8b0e1ea6-3c9b-4d26-8091-d75119f16bf0.png)
