### PR TITLE
Added Analytics dashboard that retrieves and displays reviewer count and scores

### DIFF
--- a/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentViewAnalytics.js
+++ b/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentViewAnalytics.js
@@ -7,33 +7,30 @@ angular.module('docs').controller('DocumentViewAnalytics', function ($scope, $st
     /**
      * Get ratings and reviewer count from server
      */
-    console.log($stateParams)
-    Restangular.one('file/list').get({ id: $stateParams.id }).then(function(data) {
-        $scope.files = data.files;
-    });
+    // console.log($stateParams)
+    // Restangular.one('file/list').get({ id: $stateParams.id }).then(function(data) {
+    //     $scope.num_reviews = data.???;
+    //     $scope.avg_ratings = data.???;
+    // });
+    $scope.num_reviews = 4
+    $scope.avg_ratings = [8.8, 2.3, 5.0]
 
     /**
      * Style the rating scores
      * Copied from https://codepen.io/leandroamato/pen/jOWqrGe
      */
-    // Find all rating items
-    const ratings = document.querySelectorAll(".rating");
-
     // Iterate over all rating items
-    ratings.forEach((rating) => {
+    const ratings = document.querySelectorAll(".rating");
+    ratings.forEach((rating, i) => {
         // Get content and get score as a float
-        const ratingScore = parseFloat(rating.innerHTML, 10).toFixed(1);
+        const ratingScore = parseFloat($scope.avg_ratings[i], 10).toFixed(1);
 
-        // Define if the score is good, meh, or bad according to its value
+        // Define if the score is good, meh, or bad, then add score class
         const scoreClass = ratingScore < 4.0 ? "bad" : ratingScore < 7.0 ? "meh" : "good";
-
-        // Add score class to the rating
         rating.classList.add(scoreClass);
 
-        // After adding the class, get its color
+        // After adding the class, get its color to define the background gradient
         const ratingColor = window.getComputedStyle(rating).backgroundColor;
-
-        // Define the background gradient according to the score and color
         const gradient = `background: conic-gradient(${ratingColor} ${ratingScore * 10}%, transparent 0 100%)`;
 
         // Set the gradient as the rating background

--- a/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentViewAnalytics.js
+++ b/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentViewAnalytics.js
@@ -1,8 +1,45 @@
 'use strict';
 
 /**
- * Document view workflow controller.
+ * Document view analytics controller.
  */
 angular.module('docs').controller('DocumentViewAnalytics', function ($scope, $stateParams, Restangular) {
-//   currently does nothing
+    /**
+     * Get ratings and reviewer count from server
+     */
+    console.log($stateParams)
+    Restangular.one('file/list').get({ id: $stateParams.id }).then(function(data) {
+        $scope.files = data.files;
+    });
+
+    /**
+     * Style the rating scores
+     * Copied from https://codepen.io/leandroamato/pen/jOWqrGe
+     */
+    // Find all rating items
+    const ratings = document.querySelectorAll(".rating");
+
+    // Iterate over all rating items
+    ratings.forEach((rating) => {
+        // Get content and get score as a float
+        const ratingScore = parseFloat(rating.innerHTML, 10).toFixed(1);
+
+        // Define if the score is good, meh, or bad according to its value
+        const scoreClass = ratingScore < 4.0 ? "bad" : ratingScore < 7.0 ? "meh" : "good";
+
+        // Add score class to the rating
+        rating.classList.add(scoreClass);
+
+        // After adding the class, get its color
+        const ratingColor = window.getComputedStyle(rating).backgroundColor;
+
+        // Define the background gradient according to the score and color
+        const gradient = `background: conic-gradient(${ratingColor} ${ratingScore * 10}%, transparent 0 100%)`;
+
+        // Set the gradient as the rating background
+        rating.setAttribute("style", gradient);
+
+        // Wrap the content in a tag to show it above the pseudo element that masks the bar
+        rating.innerHTML = `<span>${ratingScore}</span>`;
+    });
 });

--- a/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentViewAnalytics.js
+++ b/docs-web/src/main/webapp/src/app/docs/controller/document/DocumentViewAnalytics.js
@@ -4,39 +4,57 @@
  * Document view analytics controller.
  */
 angular.module('docs').controller('DocumentViewAnalytics', function ($scope, $stateParams, Restangular) {
-    /**
-     * Get ratings and reviewer count from server
-     */
-    // console.log($stateParams)
-    // Restangular.one('file/list').get({ id: $stateParams.id }).then(function(data) {
-    //     $scope.num_reviews = data.???;
-    //     $scope.avg_ratings = data.???;
-    // });
-    $scope.num_reviews = 4
-    $scope.avg_ratings = [8.8, 2.3, 5.0]
+    
+    $scope.loadReviews = function () {
+        /**
+         * Get number of reviews and average ratings from server
+         * model after DocumentView.js:8-12
+         * documents from DocumentResource.java:156-286
+         */
+        Restangular.one('document', $stateParams.id).get().then(function (data) {
+            $scope.num_reviews = data.num_reviews;
+            $scope.avg_ratings = [data.tech_rating, data.interpersonal_rating, data.fit_rating];
 
-    /**
-     * Style the rating scores
-     * Copied from https://codepen.io/leandroamato/pen/jOWqrGe
-     */
-    // Iterate over all rating items
-    const ratings = document.querySelectorAll(".rating");
-    ratings.forEach((rating, i) => {
-        // Get content and get score as a float
-        const ratingScore = parseFloat($scope.avg_ratings[i], 10).toFixed(1);
+            // Use below lines for testing:
+            // $scope.num_reviews = 4
+            // $scope.avg_ratings = [8.8, 5.0, 0.0]
 
-        // Define if the score is good, meh, or bad, then add score class
-        const scoreClass = ratingScore < 4.0 ? "bad" : ratingScore < 7.0 ? "meh" : "good";
-        rating.classList.add(scoreClass);
+            /**
+             * Style the rating scores
+             * Copied from https://codepen.io/leandroamato/pen/jOWqrGe
+             */
+            // Iterate over all rating items
+            const ratings = document.querySelectorAll(".rating");
+            ratings.forEach((rating, i) => {
+                // Get content (float) and round to 1 decimal
+                const ratingScore = parseFloat($scope.avg_ratings[i], 10).toFixed(1);
 
-        // After adding the class, get its color to define the background gradient
-        const ratingColor = window.getComputedStyle(rating).backgroundColor;
-        const gradient = `background: conic-gradient(${ratingColor} ${ratingScore * 10}%, transparent 0 100%)`;
+                // Define if the score is good, meh, or bad, then add score class
+                const scoreClass = ratingScore < 1.0 ? "nan" :
+                                   ratingScore < 4.0 ? "bad" :
+                                   ratingScore < 7.0 ? "meh" : "good";
+                rating.classList.add(scoreClass);
 
-        // Set the gradient as the rating background
-        rating.setAttribute("style", gradient);
+                // After adding the class, get its color
+                const ratingColor = window.getComputedStyle(rating).backgroundColor;
 
-        // Wrap the content in a tag to show it above the pseudo element that masks the bar
-        rating.innerHTML = `<span>${ratingScore}</span>`;
-    });
+                // (1) Define the background gradient, and set it as the rating background
+                // (2) Wrap the content in a tag to show it above the pseudo element that masks the bar
+                if (scoreClass == "nan") {
+                    const gradient = `background: conic-gradient(${ratingColor} 100%, transparent 0 100%)`;
+                    rating.setAttribute("style", gradient);
+                    rating.innerHTML = `<span>N/A</span>`;
+                }
+                else {
+                    const gradient = `background: conic-gradient(${ratingColor} ${ratingScore * 10}%, transparent 0 100%)`;
+                    rating.setAttribute("style", gradient);
+                    rating.innerHTML = `<span>${ratingScore}</span>`;
+                }
+            });
+        }, function (response) {
+            $scope.error = response;
+        });
+    };
+    $scope.loadReviews();
+    
 });

--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="style/colorpicker.css" type="text/css" />
     <link rel="stylesheet" href="style/pell.css" type="text/css" />
     <link rel="stylesheet" href="style/ng-onboarding.css" type="text/css" />
+    <link rel="stylesheet" href="style/ratings.css" type="text/css" />
     <link rel="stylesheet/less" href="style/main.less" type="text/css" />
     <!-- endref -->
     <link rel="stylesheet" href="../api/theme/stylesheet" type="text/css" id="theme-stylesheet" />

--- a/docs-web/src/main/webapp/src/locale/en.json
+++ b/docs-web/src/main/webapp/src/locale/en.json
@@ -153,7 +153,10 @@
         "analytics": "Analytics",
         "message": "Summary of reviewers' scores are listed here.",
         "no_reviewers": "Number of Reviewers",
-        "avg_scores": "Scores by Category"
+        "avg_scores": "Average Reviewer Scores by Category",
+        "technical_label": "Technical Skills",
+        "interpersonal_label": "Interpersonal Skills",
+        "overall_label": "Overall Fit"
       }
     },
     "edit": {

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.analytics.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.analytics.html
@@ -6,6 +6,24 @@
     <p> 3 reviewers </p>
 
     <h3>{{ 'document.view.analytics.avg_scores' | translate }}</h3>
-    <p> 80, 90, 100 </p>
+    <div style="width: 100%">
+        <div class="col-md-4 flex-container">
+            <div class="rating"> 8.4 </div>
+        </div>
+        <div class="col-md-4 flex-container">
+            <div class="rating"> 2.0 </div>
+        </div>
+        <div class="col-md-4 flex-container">
+            <div class="rating"> 5.0 </div>
+        </div>
+        <div class="col-md-4 text-center"> Technical skills </div>
+        <div class="col-md-4 text-center"> Interpersonal Skills </div>
+        <div class="col-md-4 text-center"> Overall Fit </div>
+    </div>
+
+    <p>&nbsp</p>
+    
+    
+    
 
 </div>

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.analytics.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.analytics.html
@@ -2,28 +2,19 @@
 
 <div class="well">
     
-    <h3>{{ 'document.view.analytics.no_reviewers' | translate }}</h3>
-    <p> {{num_reviews}} reviewers </p>
+    <h3>{{ 'document.view.analytics.no_reviewers' | translate }}: {{num_reviews}}</h3>
 
     <h3>{{ 'document.view.analytics.avg_scores' | translate }}</h3>
-    <div style="width: 100%">
-        <div class="col-md-4 flex-container">
-            <div class="rating"> {{avg_ratings[0]}} </div>
-        </div>
-        <div class="col-md-4 flex-container">
-            <div class="rating"> {{avg_ratings[1]}} </div>
-        </div>
-        <div class="col-md-4 flex-container">
-            <div class="rating"> {{avg_ratings[2]}} </div>
-        </div>
-        <div class="col-md-4 text-center"> Technical skills </div>
-        <div class="col-md-4 text-center"> Interpersonal Skills </div>
-        <div class="col-md-4 text-center"> Overall Fit </div>
+    <div>
+        <div class="col-md-4 flex-container"><div class="rating"> </div></div>
+        <div class="col-md-4 flex-container"><div class="rating"> </div></div>
+        <div class="col-md-4 flex-container"><div class="rating"> </div></div>
+
+        <h4 class="col-md-4 text-center">{{ 'document.view.analytics.technical_label' | translate }}</h4>
+        <h4 class="col-md-4 text-center">{{ 'document.view.analytics.interpersonal_label' | translate }}</h4>
+        <h4 class="col-md-4 text-center">{{ 'document.view.analytics.overall_label' | translate }}</h4>
     </div>
 
-    <p>&nbsp</p>
-    
-    
-    
+    <p>&nbsp</p> <!-- empty space purely to set outer <div> size -->
 
 </div>

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.analytics.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.analytics.html
@@ -3,18 +3,18 @@
 <div class="well">
     
     <h3>{{ 'document.view.analytics.no_reviewers' | translate }}</h3>
-    <p> 3 reviewers </p>
+    <p> {{num_reviews}} reviewers </p>
 
     <h3>{{ 'document.view.analytics.avg_scores' | translate }}</h3>
     <div style="width: 100%">
         <div class="col-md-4 flex-container">
-            <div class="rating"> 8.4 </div>
+            <div class="rating"> {{avg_ratings[0]}} </div>
         </div>
         <div class="col-md-4 flex-container">
-            <div class="rating"> 2.0 </div>
+            <div class="rating"> {{avg_ratings[1]}} </div>
         </div>
         <div class="col-md-4 flex-container">
-            <div class="rating"> 5.0 </div>
+            <div class="rating"> {{avg_ratings[2]}} </div>
         </div>
         <div class="col-md-4 text-center"> Technical skills </div>
         <div class="col-md-4 text-center"> Interpersonal Skills </div>

--- a/docs-web/src/main/webapp/src/style/ratings.css
+++ b/docs-web/src/main/webapp/src/style/ratings.css
@@ -15,6 +15,7 @@
     --background-color: #e7f2fa;
     --rating-color-default: #2980b9;
     --rating-color-background: #c7e1f3;
+    --rating-color-nan: #000000;
     --rating-color-good: #27ae60;
     --rating-color-meh: #f1c40f;
     --rating-color-bad: #e74c3c;
@@ -80,16 +81,18 @@
 }
 
 /* Classes to give different colors to ratings, based on their score */
+.rating.nan {
+    background: var(--rating-color-nan);
+    color: var(--rating-color-nan);
+}
 .rating.good {
     background: var(--rating-color-good);
     color: var(--rating-color-good);
 }
-
 .rating.meh {
     background: var(--rating-color-meh);
     color: var(--rating-color-meh);
 }
-
 .rating.bad {
     background: var(--rating-color-bad);
     color: var(--rating-color-bad);

--- a/docs-web/src/main/webapp/src/style/ratings.css
+++ b/docs-web/src/main/webapp/src/style/ratings.css
@@ -1,0 +1,96 @@
+/* Copied from https://codepen.io/leandroamato/pen/jOWqrGe */
+/* Generic styles just to make this pen look better */
+.flex-container {
+    display: flex;
+    justify-content: center;
+}
+  
+/* ----- The actual thing ----- */
+
+/* Variables */
+
+:root {
+    --rating-size: 10rem;
+    --bar-size: 1rem;
+    --background-color: #e7f2fa;
+    --rating-color-default: #2980b9;
+    --rating-color-background: #c7e1f3;
+    --rating-color-good: #27ae60;
+    --rating-color-meh: #f1c40f;
+    --rating-color-bad: #e74c3c;
+}
+
+/* Rating item */
+.rating {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 100%;
+    overflow: hidden;
+
+    background: var(--rating-color-default);
+    color: var(--rating-color-default);
+    width: var(--rating-size);
+    height: var(--rating-size);
+
+    /* Basic style for the text */
+    font-size: calc(var(--rating-size) / 3);
+    line-height: 1;
+}
+
+/* Rating circle content */
+.rating span {
+    position: relative;
+    display: flex;
+    font-weight: bold;
+    z-index: 2;
+}
+
+.rating span small {
+    font-size: 0.5em;
+    font-weight: 900;
+    align-self: center;
+}
+
+/* Bar mask, creates an inner circle with the same color as thee background */
+.rating::after {
+    content: "";
+    position: absolute;
+    top: var(--bar-size);
+    right: var(--bar-size);
+    bottom: var(--bar-size);
+    left: var(--bar-size);
+    background: var(--background-color);
+    border-radius: inherit;
+    z-index: 1;
+}
+
+/* Bar background */
+.rating::before {
+    content: "";
+    position: absolute;
+    top: var(--bar-size);
+    right: var(--bar-size);
+    bottom: var(--bar-size);
+    left: var(--bar-size);
+    border-radius: inherit;
+    box-shadow: 0 0 0 1rem var(--rating-color-background);
+    z-index: -1;
+}
+
+/* Classes to give different colors to ratings, based on their score */
+.rating.good {
+    background: var(--rating-color-good);
+    color: var(--rating-color-good);
+}
+
+.rating.meh {
+    background: var(--rating-color-meh);
+    color: var(--rating-color-meh);
+}
+
+.rating.bad {
+    background: var(--rating-color-bad);
+    color: var(--rating-color-bad);
+}  


### PR DESCRIPTION
Resolves #8 

**Description**
Updated “Analytics” tab to receive, stylize, and display the "number of reviewers" and "average reviewer score per category" for each user document. The contents are put into scope by the DocumentViewAnalytics controller which parses the documents from DocumentResource.java. The contents are parsed and stylized using Bootstrap and "circle progress bar" code from https://codepen.io/leandroamato/pen/jOWqrGe. The contents are then read by the HTML template in document.view.analytics.html and shown on the screen.

**Changes:**
- document.view.analytics.html -> front-end of the Analytics tab, uses HTML templates to get scope variables
- DocumentViewAnalytics.js -> JavaScript controller that (1) retrieves number of reviewers and average scores, and (2) helps stylize the average scores
- ratings.css -> styling guidelines for average reviewer scores; displays as colorful circle bars based on the values of the averages

**Testing:**
Passes all old tests after running the command `$ mvn test`. Passes manual inspection of creating a document and seeing the default data (no of reviewers + average scores) displayed in the proper manner. There is no Java tests that can be created at this stage because the middleware (at this stage) isn't complete, so the Teedy API cannot be run yet.

**Screenshot of the Current Output:**
![Screen Shot 2022-10-04 at 6 49 51 PM](https://user-images.githubusercontent.com/45546627/193949908-b725e22f-b54d-486f-8b62-98814cc84425.png)
