### PR TITLE
Modified GET API to return percentage instead of decimal 

### DIFF
--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/RatingResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/RatingResource.java
@@ -111,7 +111,7 @@ public class RatingResource extends BaseResource {
 		int numReviews = document.getNumReviews();
 		int totalActiveUsers = (int)userDao.getActiveUserCount();
 
-		float percentRating = (float) numReviews / totalActiveUsers;
+		float percentRating = (float) numReviews / totalActiveUsers * 100;
 		response.add("percentage_rating", percentRating);
 
 		return Response.ok().entity(response.build()).build();

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestRatingResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestRatingResource.java
@@ -243,7 +243,7 @@ public class TestRatingResource extends BaseJerseyTest {
 		.get(JsonObject.class);
 
 		JsonNumber percentage1 = json.getJsonNumber("percentage_rating");
-		Assert.assertEquals(percentage1.doubleValue(),0.125, 0);
+		Assert.assertEquals(percentage1.doubleValue(),12.5, 0);
 		Assert.assertEquals("ok", status);
 		// logout user7
 		clientUtil.logout(userToken7);


### PR DESCRIPTION
Resolves #22 
**Description**
We realized that the analytics tab was constantly displaying 1% because it is rounding the decimal return by the GET API to the nearest integer. To fix this bug, we changed the GET API to directly return a percentage (0 ≤ x ≤ 100). 

**Testing**
<img width="662" alt="Screen Shot 2022-10-06 at 22 05 23" src="https://user-images.githubusercontent.com/79778718/194451033-88eb70e5-74d8-4885-8662-a62aeefabffe.png">
Build success. Screenshot shows that "Percentage of Reviews Completed" is now 50% instead of 1%